### PR TITLE
Raise error on slack authentication errors

### DIFF
--- a/lib/adapters/slack/slack_http_client.rb
+++ b/lib/adapters/slack/slack_http_client.rb
@@ -11,9 +11,11 @@ module Slacker
       end
 
       def start_rtm
-        json_parse self.get('rtm.start', {
+        response = json_parse self.get('rtm.start', {
           :token => @token
         })
+        raise "Invalid Slack authentication" if response["error"] == "invalid_auth"
+        response
       end
     end
   end


### PR DESCRIPTION
I had some trouble getting this running locally and the error returned was unhelpful, this might make it a little easier for people setting it up initially.